### PR TITLE
fix: dynamic list name

### DIFF
--- a/src/components/sidebar.php
+++ b/src/components/sidebar.php
@@ -2,65 +2,30 @@
 require_once __DIR__ . '/../db.php';
 require_once __DIR__ . '/../lib/auth.php';
 require_once __DIR__ . '/menu-item.php';
-require_once __DIR__ . '/icon.php';
+class Sidebar {
+  private $staticMenuItems;
+  private $dynamicMenuItems = [];
 
-$db = Database::getInstance();
-$user = Auth::getUser();
+  public function __construct() {
+    $db = Database::getInstance();
+    $user = Auth::getUser();
 
-$query = $db->prepare("SELECT * FROM lists WHERE user_id = :id");
-$query->execute(['id' => $user['id']]);
-$lists = $query->fetchAll();
+    $query = $db->prepare("SELECT * FROM lists WHERE user_id = :id");
+    $query->execute(['id' => $user['id']]);
+    $lists = $query->fetchAll();
 
-$dynamicMenuItems = [];
-foreach ($lists as $list) {
-  array_push($dynamicMenuItems, new MenuItem($list['name'], '/list.php?id=' . $list['id'], null));
+    foreach ($lists as $list) {
+      $this->dynamicMenuItems[] = new MenuItem($list['name'], '/list.php?id=' . $list['id'], null);
+    }
+
+    $this->staticMenuItems = [
+      new MenuItem('Inbox', '/', 'inbox'),
+      new MenuItem('Today', '/today.php', 'calendar'),
+      new MenuItem('Done', '/done.php', 'check')
+    ];
+  }
+
+  public function render() {
+    require __DIR__ . '/sidebar.template.php';
+  }
 }
-
-$staticMenuItems = [
-  new MenuItem('Inbox', '/', 'inbox'),
-  new MenuItem('Today', '/today.php', 'calendar'),
-  new MenuItem('Done', '/done.php', 'check')
-]
-?>
-
-<aside id="sidebar" class="sidebar hidden">
-  <div class="main">
-    <header>
-      <?php
-      require_once __DIR__ . '/logo.php';
-      ?>
-
-      <button id="close-sidebar">
-        <span>close menu</span>
-        <?php
-        $icon = new Icon('x', 24);
-        $icon->render();
-        ?>
-      </button>
-    </header>
-    <nav>
-      <div class="static-menu-items">
-        <?php
-        foreach ($staticMenuItems as $item) {
-          $item->render();
-        }
-        ?>
-      </div>
-      <div class="separator"></div>
-      <div class="dynamic-menu-items">
-        <?php
-        foreach ($dynamicMenuItems as $item) {
-          $item->render();
-        }
-        ?>
-      </div>
-    </nav>
-  </div>
-  <button id="open-add-list-modal">
-    <?php
-    $icon = new Icon('plus', 16);
-    $icon->render();
-    ?>
-    <span>New list</span>
-  </button>
-</aside>

--- a/src/components/sidebar.template.php
+++ b/src/components/sidebar.template.php
@@ -1,0 +1,45 @@
+<?php
+require_once __DIR__ . '/icon.php';
+?>
+
+<aside id="sidebar" class="sidebar hidden">
+  <div class="main">
+    <header>
+      <?php
+      require_once __DIR__ . '/logo.php';
+      ?>
+
+      <button id="close-sidebar">
+        <span>close menu</span>
+        <?php
+        $icon = new Icon('x', 24);
+        $icon->render();
+        ?>
+      </button>
+    </header>
+    <nav>
+      <div class="static-menu-items">
+        <?php
+        foreach ($this->staticMenuItems as $item) {
+          $item->render();
+        }
+        ?>
+      </div>
+      <div class="separator"></div>
+      <div class="dynamic-menu-items">
+        <?php
+        foreach ($this->dynamicMenuItems as $item) {
+          $item->render();
+        }
+        ?>
+      </div>
+    </nav>
+  </div>
+  <button id="open-add-list-modal">
+    <?php
+    $icon = new Icon('plus', 16);
+    $icon->render();
+    ?>
+    <span>New list</span>
+  </button>
+</aside>

--- a/src/done.php
+++ b/src/done.php
@@ -27,7 +27,12 @@ $title = 'Done';
 ob_start();
 ?>
 
-<?php require_once __DIR__ . '/components/sidebar.php' ?>
+<?php
+require_once __DIR__ . '/components/sidebar.php';
+
+$sidebar = new Sidebar();
+$sidebar->render();
+?>
 <main class="list container">
   <div>
     <?php

--- a/src/index.php
+++ b/src/index.php
@@ -39,7 +39,12 @@ $title = 'Inbox';
 ob_start();
 ?>
 
-<?php require_once __DIR__ . '/components/sidebar.php' ?>
+<?php
+require_once __DIR__ . '/components/sidebar.php';
+
+$sidebar = new Sidebar();
+$sidebar->render();
+?>
 <main class="list container">
   <div>
     <?php

--- a/src/list.php
+++ b/src/list.php
@@ -56,7 +56,12 @@ $title = $list['name'];
 ob_start();
 ?>
 
-<?php require_once __DIR__ . '/components/sidebar.php' ?>
+<?php
+require_once __DIR__ . '/components/sidebar.php';
+
+$sidebar = new Sidebar();
+$sidebar->render();
+?>
 <main class="list container">
   <div>
     <?php

--- a/src/task.php
+++ b/src/task.php
@@ -41,7 +41,12 @@ $title = $task['name'];
 ob_start();
 ?>
 
-<?php require_once __DIR__ . '/components/sidebar.php' ?>
+<?php
+require_once __DIR__ . '/components/sidebar.php';
+
+$sidebar = new Sidebar();
+$sidebar->render();
+?>
 <main class="details container">
   <div>
     <?php

--- a/src/today.php
+++ b/src/today.php
@@ -39,7 +39,12 @@ $title = 'Inbox';
 ob_start();
 ?>
 
-<?php require_once __DIR__ . '/components/sidebar.php' ?>
+<?php
+require_once __DIR__ . '/components/sidebar.php';
+
+$sidebar = new Sidebar();
+$sidebar->render();
+?>
 <main class="list container">
   <div>
     <?php


### PR DESCRIPTION
this was a fun one... because of the `foreach ($lists as $list) {` in `sidebar.php` the `$list['name']` passed into `new Header` in `list.php` would always be overridden with the last list in that loop. i don't like php

solved by making sidebar a class component. maybe i should make all components class component to avoid this madness